### PR TITLE
feat: More configs for DialogTextField

### DIFF
--- a/lib/src/text_input_dialog/cupertino_text_input_dialog.dart
+++ b/lib/src/text_input_dialog/cupertino_text_input_dialog.dart
@@ -123,6 +123,11 @@ class _CupertinoTextInputDialogState extends State<CupertinoTextInputDialog> {
                 autofocus: i == 0,
                 placeholder: field.hintText,
                 obscureText: field.obscureText,
+                keyboardType: field.keyboardType,
+                prefix:
+                    field.prefixText != null ? Text(field.prefixText) : null,
+                suffix:
+                    field.suffixText != null ? Text(field.suffixText) : null,
                 decoration: _borderDecoration(
                   isTopRounded: i == 0,
                   isBottomRounded: i == _textControllers.length - 1,

--- a/lib/src/text_input_dialog/material_text_input_dialog.dart
+++ b/lib/src/text_input_dialog/material_text_input_dialog.dart
@@ -95,8 +95,11 @@ class _MaterialTextInputDialogState extends State<MaterialTextInputDialog> {
                 controller: c,
                 autofocus: i == 0,
                 obscureText: textField.obscureText,
+                keyboardType: textField.keyboardType,
                 decoration: InputDecoration(
                   hintText: textField.hintText,
+                  prefixText: textField.prefixText,
+                  suffixText: textField.suffixText,
                 ),
                 validator: textField.validator,
                 autovalidateMode: _autovalidateMode,

--- a/lib/src/text_input_dialog/text_input_dialog.dart
+++ b/lib/src/text_input_dialog/text_input_dialog.dart
@@ -63,9 +63,15 @@ class DialogTextField {
     this.hintText,
     this.obscureText = false,
     this.validator,
+    this.keyboardType,
+    this.prefixText,
+    this.suffixText,
   });
   final String initialText;
   final String hintText;
   final bool obscureText;
   final FormFieldValidator<String> validator;
+  final TextInputType keyboardType;
+  final String prefixText;
+  final String suffixText;
 }


### PR DESCRIPTION
Hey :-)

first of all I would like to say a big thank you for this awesome package. It makes dialog handling much much easier in my apps. One missing thing for me is configuration of the keyboardType, and prefix and suffix text in the DialogTextField. In my app the user can set a url, where it is very useful, if I can set prefixText to "https://" and the keyboardType to "url". This Pull Request implements it. I hope you like it.

Have a nice day and stay healthy in this scary times