### PR TITLE
feat: minLines and maxLines for DialogTextField

### DIFF
--- a/lib/src/text_input_dialog/cupertino_text_input_dialog.dart
+++ b/lib/src/text_input_dialog/cupertino_text_input_dialog.dart
@@ -124,6 +124,8 @@ class _CupertinoTextInputDialogState extends State<CupertinoTextInputDialog> {
                 placeholder: field.hintText,
                 obscureText: field.obscureText,
                 keyboardType: field.keyboardType,
+                minLines: field.minLines,
+                maxLines: field.maxLines,
                 prefix:
                     field.prefixText != null ? Text(field.prefixText) : null,
                 suffix:

--- a/lib/src/text_input_dialog/material_text_input_dialog.dart
+++ b/lib/src/text_input_dialog/material_text_input_dialog.dart
@@ -96,6 +96,8 @@ class _MaterialTextInputDialogState extends State<MaterialTextInputDialog> {
                 autofocus: i == 0,
                 obscureText: textField.obscureText,
                 keyboardType: textField.keyboardType,
+                minLines: textField.minLines,
+                maxLines: textField.maxLines,
                 decoration: InputDecoration(
                   hintText: textField.hintText,
                   prefixText: textField.prefixText,

--- a/lib/src/text_input_dialog/text_input_dialog.dart
+++ b/lib/src/text_input_dialog/text_input_dialog.dart
@@ -66,6 +66,8 @@ class DialogTextField {
     this.keyboardType,
     this.prefixText,
     this.suffixText,
+    this.minLines,
+    this.maxLines,
   });
   final String initialText;
   final String hintText;
@@ -74,4 +76,6 @@ class DialogTextField {
   final TextInputType keyboardType;
   final String prefixText;
   final String suffixText;
+  final int minLines;
+  final int maxLines;
 }


### PR DESCRIPTION
Hello again, :-)

thanks for merging my last request. Here I have made a tiny change so that you can set minLines and maxLines for a text field. I need this to set some data in my app [FluffyChat](https://fluffychat.im):

![Bildschirmfoto vom 2020-11-23 17-24-57](https://user-images.githubusercontent.com/24619905/99987570-ec7c5f80-2db0-11eb-9a58-a3c56c6cc7ed.png)

I hope you like it! :)

Best regards and stay healthy!