### PR TITLE
Colour dialog elements according to current theme

### DIFF
--- a/lib/src/alert_dialog/alert_dialog_action.dart
+++ b/lib/src/alert_dialog/alert_dialog_action.dart
@@ -46,12 +46,13 @@ extension AlertDialogActionEx<T> on AlertDialogAction<T> {
     required ActionCallback<T> onPressed,
     required Color destructiveColor,
     required bool fullyCapitalized,
+    required ThemeData theme,
   }) {
     return TextButton(
       child: Text(
         fullyCapitalized ? label.toUpperCase() : label,
         style: textStyle.copyWith(
-          color: isDestructiveAction ? destructiveColor : null,
+          color: isDestructiveAction ? destructiveColor : theme.accentColor,
         ),
       ),
       onPressed: () => onPressed(key),
@@ -71,11 +72,13 @@ extension AlertDialogActionListEx<T> on List<AlertDialogAction<T>> {
     required ActionCallback<T> onPressed,
     required Color destructiveColor,
     required bool fullyCapitalized,
+    required ThemeData theme,
   }) =>
       map((a) => a.convertToMaterialDialogAction(
             onPressed: onPressed,
             destructiveColor: destructiveColor,
             fullyCapitalized: fullyCapitalized,
+            theme: theme,
           )).toList();
 
   List<SheetAction<T>> convertToSheetActions() =>

--- a/lib/src/alert_dialog/show_alert_dialog.dart
+++ b/lib/src/alert_dialog/show_alert_dialog.dart
@@ -62,12 +62,16 @@ Future<T?> showAlertDialog<T>({
             barrierDismissible: barrierDismissible,
           ),
           builder: (context) => AlertDialog(
+            backgroundColor: theme.cardColor,
+            titleTextStyle: theme.textTheme.headline6,
             title: titleText,
+            contentTextStyle: theme.textTheme.subtitle1,
             content: messageText,
             actions: actions.convertToMaterialDialogActions(
               onPressed: pop,
               destructiveColor: colorScheme.error,
               fullyCapitalized: fullyCapitalizedForMaterial,
+              theme: theme,
             ),
             actionsOverflowDirection: actionsOverflowDirection,
           ),


### PR DESCRIPTION
`showAlertDialog` already has the current theme - this PR uses some of its attributes to colour the corresponding elements of the dialog box shown. Fixes the dialog box bug seen [here](https://gitlab.com/famedly/fluffychat/-/issues/264).