### PR TITLE
add ignore keyword sensitive option for showTextAnswerDialog

### DIFF
--- a/lib/src/text_input_dialog/text_answer_dialog.dart
+++ b/lib/src/text_input_dialog/text_answer_dialog.dart
@@ -20,7 +20,7 @@ Future<bool> showTextAnswerDialog({
   VerticalDirection actionsOverflowDirection = VerticalDirection.up,
   bool fullyCapitalizedForMaterial = true,
   WillPopCallback? onWillPop,
-  bool ignoreKeywordSensitive = false,
+  bool isCaseSensitive = true,
 }) async {
   final texts = await showTextInputDialog(
     context: context,
@@ -41,9 +41,9 @@ Future<bool> showTextAnswerDialog({
   if (text == null) {
     return false;
   }
-  if (ignoreKeywordSensitive
-      ? text.toUpperCase() == keyword.toUpperCase()
-      : text == keyword) {
+  if (isCaseSensitive
+      ? text == keyword
+      : text.toUpperCase() == keyword.toUpperCase()) {
     return true;
   }
   final result = await showOkCancelAlertDialog(


### PR DESCRIPTION
For some case scenarios, it might be not necessary to validate the keyword's case-sensitive as the word could be auto capitalized by the phone and it will be a hassle for the user to switch it back to pass the validation.

This new option will ignore the keyword case-sensitive, and the default value is false.