### PR TITLE
Change message type to Text, so it could take Text.rich to has TextSt…

### DIFF
--- a/example/lib/pages/text_input_dialog_page.dart
+++ b/example/lib/pages/text_input_dialog_page.dart
@@ -53,7 +53,7 @@ class TextInputDialogPage extends StatelessWidget {
                   ),
                 ],
                 title: 'Hello',
-                message: 'This is a message',
+                message: const Text('This is a message'),
               );
               logger.info(text);
             },
@@ -77,7 +77,7 @@ class TextInputDialogPage extends StatelessWidget {
                   ),
                 ],
                 title: 'Hello',
-                message: 'This is a message',
+                message: const Text('This is a message'),
               );
               logger.info(text);
             },
@@ -101,7 +101,7 @@ class TextInputDialogPage extends StatelessWidget {
                   ),
                 ],
                 title: 'Hello',
-                message: 'This is a message',
+                message: const Text('This is a message'),
                 autoSubmit: true,
               );
               logger.info(text);
@@ -120,7 +120,7 @@ class TextInputDialogPage extends StatelessWidget {
                   ),
                 ],
                 title: 'Hello',
-                message: 'This is a message',
+                message: const Text('This is a message'),
               );
               logger.info(text);
             },
@@ -141,7 +141,7 @@ class TextInputDialogPage extends StatelessWidget {
                   ),
                 ],
                 title: 'Hello',
-                message: 'This is a message',
+                message: const Text('This is a message'),
               );
               logger.info(text);
             },
@@ -153,7 +153,7 @@ class TextInputDialogPage extends StatelessWidget {
                 context: context,
                 keyword: 'Flutter',
                 title: 'What\'s the best mobile application framework?',
-                message: 'Input answer and press OK',
+                message: const Text('Input answer and press OK'),
                 isDestructiveAction: true,
                 hintText: 'Start with "F"',
                 retryTitle: 'Incorrect',

--- a/lib/src/text_input_dialog/cupertino_text_input_dialog.dart
+++ b/lib/src/text_input_dialog/cupertino_text_input_dialog.dart
@@ -24,7 +24,7 @@ class CupertinoTextInputDialog extends StatefulWidget {
 
   final List<DialogTextField> textFields;
   final String? title;
-  final String? message;
+  final Text? message;
   final String? okLabel;
   final String? cancelLabel;
   final bool isDestructiveAction;
@@ -128,7 +128,7 @@ class _CupertinoTextInputDialogState extends State<CupertinoTextInputDialog> {
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            if (message != null) Text(message),
+            if (message != null) message,
             const SizedBox(height: 22),
             ..._textControllers.mapIndexed(
               (i, c) {

--- a/lib/src/text_input_dialog/material_text_input_dialog.dart
+++ b/lib/src/text_input_dialog/material_text_input_dialog.dart
@@ -24,7 +24,7 @@ class MaterialTextInputDialog extends StatefulWidget {
 
   final List<DialogTextField> textFields;
   final String? title;
-  final String? message;
+  final Text? message;
   final String? okLabel;
   final String? cancelLabel;
   final bool isDestructiveAction;
@@ -106,7 +106,7 @@ class _MaterialTextInputDialogState extends State<MaterialTextInputDialog> {
                     padding: const EdgeInsets.only(bottom: 8),
                     child: Scrollbar(
                       child: SingleChildScrollView(
-                        child: Text(message),
+                        child: message,
                       ),
                     ),
                   ),

--- a/lib/src/text_input_dialog/text_answer_dialog.dart
+++ b/lib/src/text_input_dialog/text_answer_dialog.dart
@@ -5,7 +5,7 @@ Future<bool> showTextAnswerDialog({
   required BuildContext context,
   required String keyword,
   String? title,
-  String? message,
+  Text? message,
   String? okLabel,
   String? cancelLabel,
   bool isDestructiveAction = false,

--- a/lib/src/text_input_dialog/text_input_dialog.dart
+++ b/lib/src/text_input_dialog/text_input_dialog.dart
@@ -10,7 +10,7 @@ Future<List<String>?> showTextInputDialog({
   required BuildContext context,
   required List<DialogTextField> textFields,
   String? title,
-  String? message,
+  Text? message,
   String? okLabel,
   String? cancelLabel,
   bool isDestructiveAction = false,


### PR DESCRIPTION
I think accepting Text instead of String for message property could be a better option.

Considering if the user wants to bold some text in the message, they won't be able to do so at this moment. But if we change the message type to Text, they could use ```Text.Rich()``` to style their whole message or just part of the message in any way they want to.

If they don't care, could just use Text('<String>') to pass in the plain text.

If you're agreeing with this approach, I could change all those dialogs, this commit only contains changes for ```showTextAnswerDialog``` as that's the one I am using.
