### PR TITLE
fix: pop with dialog context

### DIFF
--- a/lib/src/alert_dialog/show_alert_dialog.dart
+++ b/lib/src/alert_dialog/show_alert_dialog.dart
@@ -30,11 +30,11 @@ Future<T?> showAlertDialog<T>({
   Widget? macOSApplicationIcon,
   RouteSettings? routeSettings,
 }) {
-  final navigator = Navigator.of(
-    context,
-    rootNavigator: useRootNavigator,
-  );
-  void pop(T? key) => navigator.pop(key);
+  void pop({required BuildContext context, required T? key}) => Navigator.of(
+        context,
+        rootNavigator: useRootNavigator,
+      ).pop(key);
+
   final theme = Theme.of(context);
   final colorScheme = theme.colorScheme;
   final adaptiveStyle = style ?? AdaptiveDialog.instance.defaultStyle;
@@ -53,6 +53,7 @@ Future<T?> showAlertDialog<T>({
       routeSettings: routeSettings,
     );
   }
+
   final titleText = title == null ? null : Text(title);
   final messageText = message == null ? null : Text(message);
 
@@ -75,7 +76,7 @@ Future<T?> showAlertDialog<T>({
               actions: actions
                   .map(
                     (a) => a.convertToIOSDialogAction(
-                      onPressed: pop,
+                      onPressed: (key) => pop(context: context, key: key),
                     ),
                   )
                   .toList(),
@@ -103,7 +104,7 @@ Future<T?> showAlertDialog<T>({
               actions: actions
                   .map(
                     (a) => a.convertToMaterialDialogAction(
-                      onPressed: pop,
+                      onPressed: (key) => pop(context: context, key: key),
                       destructiveColor: colorScheme.error,
                       fullyCapitalized: fullyCapitalizedForMaterial,
                     ),

--- a/lib/src/alert_dialog/show_confirmation_dialog.dart
+++ b/lib/src/alert_dialog/show_confirmation_dialog.dart
@@ -33,11 +33,11 @@ Future<T?> showConfirmationDialog<T>({
   AdaptiveDialogBuilder? builder,
   RouteSettings? routeSettings,
 }) {
-  final navigator = Navigator.of(
-    context,
-    rootNavigator: useRootNavigator,
-  );
-  void pop(T? key) => navigator.pop(key);
+  void pop({required BuildContext context, required T? key}) => Navigator.of(
+        context,
+        rootNavigator: useRootNavigator,
+      ).pop(key);
+
   final theme = Theme.of(context);
   final adaptiveStyle = style ?? AdaptiveDialog.instance.defaultStyle;
   return adaptiveStyle.isMaterial(theme)
@@ -51,7 +51,7 @@ Future<T?> showConfirmationDialog<T>({
           builder: (context) {
             final dialog = _ConfirmationMaterialDialog(
               title: title,
-              onSelect: pop,
+              onSelect: (key) => pop(context: context, key: key),
               message: message,
               okLabel: okLabel,
               cancelLabel: cancelLabel,

--- a/lib/src/modal_action_sheet/modal_action_sheet.dart
+++ b/lib/src/modal_action_sheet/modal_action_sheet.dart
@@ -27,11 +27,11 @@ Future<T?> showModalActionSheet<T>({
   AdaptiveDialogBuilder? builder,
   RouteSettings? routeSettings,
 }) {
-  final navigator = Navigator.of(
-    context,
-    rootNavigator: useRootNavigator,
-  );
-  void pop(T? key) => navigator.pop(key);
+  void pop({required BuildContext context, required T? key}) => Navigator.of(
+        context,
+        rootNavigator: useRootNavigator,
+      ).pop(key);
+
   final theme = Theme.of(context);
   final adaptiveStyle = style ?? AdaptiveDialog.instance.defaultStyle;
   return adaptiveStyle.isMaterial(theme)
@@ -43,7 +43,7 @@ Future<T?> showModalActionSheet<T>({
           routeSettings: routeSettings,
           builder: (context) {
             final sheet = MaterialModalActionSheet(
-              onPressed: pop,
+              onPressed: (key) => pop(context: context, key: key),
               title: title,
               message: message,
               actions: actions,
@@ -59,7 +59,7 @@ Future<T?> showModalActionSheet<T>({
           routeSettings: routeSettings,
           builder: (context) {
             final sheet = CupertinoModalActionSheet(
-              onPressed: pop,
+              onPressed: (key) => pop(context: context, key: key),
               title: title,
               message: message,
               actions: actions,


### PR DESCRIPTION
Dialog use its provided context to pop. This cause the context to be disposed and can't be reused.

```dart
var result = await showAdaptiveDialog(context)

// cause error here as context is disposed.
if(ok) showSnackBar(context)
```